### PR TITLE
Add object-shorthand rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,6 +142,7 @@ module.exports = {
     'no-useless-constructor': 2,
     'no-useless-rename': 2,
     'no-var': 2,
+    'object-shorthand': 2,
     'prefer-arrow-callback': [2, {"allowUnboundThis": false}],
     'prefer-const': 2,
     'prefer-numeric-literals': 2,


### PR DESCRIPTION
[http://eslint.org/docs/rules/object-shorthand](http://eslint.org/docs/rules/object-shorthand)

Prefer
`let foo = {x, y, z}`
to
`let foo = {x: x, y: y, z: z}`.