### PR TITLE
Change deprecated jsx-space-before-closing to jsx-tag-spacing

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ module.exports = {
     'react/jsx-key': 2,
     'react/jsx-no-duplicate-props': 2,
     'react/jsx-no-undef': 2,
-    'react/jsx-space-before-closing': [2, 'always'],
+    'react/jsx-tag-spacing': 2,
     'react/jsx-uses-react': 2,
     'react/jsx-uses-vars': 2,
     'react/jsx-wrap-multilines': 2,


### PR DESCRIPTION
https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-tag-spacing.md
The `beforeSelfClosing: 'always'` option is default.