### PR TITLE
Change space-before-function-paren rule options

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ module.exports = {
     'semi': [2, 'never'],
     'semi-spacing': [2, {'before': false, 'after': true}],
     'space-before-blocks': [2, 'always'],
-    'space-before-function-paren': [2, 'never'],
+    'space-before-function-paren': [2, {'anonymous': 'never', 'named': 'never', 'asyncArrow': 'always'}],
     'space-in-parens': [2, 'never'],
     'space-unary-ops': [2, {'words': true, 'nonwords': false}],
     'unicode-bom': 2,


### PR DESCRIPTION
We use `async () => {}` instead of `async() => {}`.