### PR TITLE
Add space-infix-ops rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,6 +126,7 @@ module.exports = {
     'space-before-blocks': [2, 'always'],
     'space-before-function-paren': [2, {'anonymous': 'never', 'named': 'never', 'asyncArrow': 'always'}],
     'space-in-parens': [2, 'never'],
+    'space-infix-ops': 2,
     'space-unary-ops': [2, {'words': true, 'nonwords': false}],
     'unicode-bom': 2,
     'arrow-parens': [2, 'always'],


### PR DESCRIPTION
We want to have spaces around operators like `+`, `=` and `? :`, see https://eslint.org/docs/rules/space-infix-ops.