### PR TITLE
Remove guard-for-in rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,6 @@ module.exports = {
     'dot-location': [2, 'property'],
     'dot-notation': 2,
     'eqeqeq': [2, 'allow-null'],
-    'guard-for-in': 1,
     'no-alert': 2,
     'no-caller': 2,
     'no-case-declarations': 2,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-vacuumlabs",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "ESLint shareable config for the VacuumLabs style",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
rationale:

It's safe to assume that no sane person will modify `Object.prototype`
(neither would I use library that does so) Therefore, such rule makes
sense only when majority of objects are not plain objects. In projects I
have somevisibility to, we prefer working with simple types (i.e. plain
objects) and functions operating on top of them. May there be some
custom class, usually you don't want to iterate over it's properties, it
does not make much sense.

Knex's resultsets are the only exception that comes to mind right now.